### PR TITLE
fix: Melhorias interface e reconexão

### DIFF
--- a/poker-planning-v3/src/backend/poker-game.ts
+++ b/poker-planning-v3/src/backend/poker-game.ts
@@ -11,7 +11,10 @@ import type { DefaultEventsMap, Server } from "socket.io";
 
 const games = new Map<string, gameType>();
 const disconnectionTimeouts = new Map<string, NodeJS.Timeout>();
-const DISCONNECTION_DELAY = 30000; // 30 segundos
+/*o tempo tipico para um usuario saber que ficou offline é de 45 segundos
+ * 25 segundos do "ping" do socket.io + 20 segundos do "pong"
+ */
+const DISCONNECTION_DELAY = 300000; // 300 segundos ou 5 minutos
 
 function addPlayer(
   gameId: string,

--- a/poker-planning-v3/src/frontend/usePokerGame.ts
+++ b/poker-planning-v3/src/frontend/usePokerGame.ts
@@ -130,6 +130,30 @@ export function usePokerGame() {
     setGame(undefined);
   }, [clearStoredGameData]);
 
+  const onPlayerClientDisconnect = useCallback(() => {
+    if (!game || !playerId) {
+      return;
+    }
+
+    const newPlayers = game.players.map((p) => {
+      if (p.id !== playerId) {
+        return p;
+      }
+
+      return {
+        ...p,
+        isDisconnected: true,
+      };
+    });
+
+    const newGame = {
+      ...game,
+      players: newPlayers,
+    };
+
+    setGame(newGame);
+  }, [game, playerId]);
+
   //#region emmitted events
 
   //#endregion
@@ -155,9 +179,10 @@ export function usePokerGame() {
         return prev ?? [];
       });
     });
-    socket.on("disconnect", () => {
-      console.log("Socket desconectado, tentando reconectar...");
+    socket.on("disconnect", (r) => {
+      console.log("Socket desconectado, tentando reconectar...", r);
       setTimeout(attemptReconnection, 1000);
+      onPlayerClientDisconnect();
     });
     socket.on("connect", () => {
       console.log("Socket reconectado!");
@@ -185,6 +210,7 @@ export function usePokerGame() {
     getPlayerId,
     getStoredGameData,
     isReconnecting,
+    onPlayerClientDisconnect,
     playerId,
     resetReconnectionAttempts,
   ]);


### PR DESCRIPTION
Este PR tem a intenção de corrigir alguns problemas vistos na ultima poker. 
O primeiro é que a desconexão era vista apenas para os outros participantes da poker, e não para o proprio usuario. O ajuste foi setar a flag no front, no evento de disconect.
O segundo era o tempo até a remoção do jogador. Antes era de 30 segundos, pesquisando no chatgpt, parece que eu preciso de no minimo 45 segundos para que o usuario saiba que foi desconectado sem ter interações. Então eu mudei o limite para 5 minutos